### PR TITLE
Changed path.joining

### DIFF
--- a/pkg/scraping/client.go
+++ b/pkg/scraping/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/url"
+	"path/filepath"
 	"time"
 
 	"github.com/wavesplatform/gowaves/pkg/client"
@@ -30,7 +32,12 @@ func (c *nodeClient) version(ctx context.Context) (string, error) {
 		Version string `json:"version"`
 	}
 	nodeURL := c.cl.GetOptions().BaseUrl
-	versionRequest, err := http.NewRequest("GET", nodeURL+"/node/version", nil)
+	nodeVersionUrl, err := joinPath(nodeURL, "/node/version")
+	if err != nil {
+		log.Printf("Failed to join path to the node url while getting version, %v", err)
+		return "", err
+	}
+	versionRequest, err := http.NewRequest("GET", nodeVersionUrl.String(), nil)
 	if err != nil {
 		log.Printf("Creation of version request to %q failed: %v", nodeURL, err)
 		return "", err
@@ -63,4 +70,18 @@ func (c *nodeClient) stateHash(ctx context.Context, height int) (*proto.StateHas
 		return nil, err
 	}
 	return sh, nil
+}
+
+func joinPath(baseRaw, pathRow string) (*url.URL, error) {
+	baseUrl, err := url.Parse(baseRaw)
+	if err != nil {
+		return nil, err
+	}
+	addUrl, err := url.Parse(pathRow)
+	if err != nil {
+		return nil, err
+	}
+	baseUrl.Path = filepath.Join(baseUrl.Path, addUrl.Path)
+
+	return baseUrl, nil
 }

--- a/pkg/scraping/client.go
+++ b/pkg/scraping/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/wavesplatform/gowaves/pkg/client"
@@ -31,7 +30,7 @@ func (c *nodeClient) version(ctx context.Context) (string, error) {
 		Version string `json:"version"`
 	}
 	nodeURL := c.cl.GetOptions().BaseUrl
-	versionRequest, err := http.NewRequest("GET", path.Join(nodeURL, "/node/version"), nil)
+	versionRequest, err := http.NewRequest("GET", nodeURL+"/node/version", nil)
 	if err != nil {
 		log.Printf("Creation of version request to %q failed: %v", nodeURL, err)
 		return "", err

--- a/pkg/scraping/client.go
+++ b/pkg/scraping/client.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"time"
 
 	"github.com/wavesplatform/gowaves/pkg/client"
@@ -81,7 +81,7 @@ func joinPath(baseRaw, pathRow string) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	baseUrl.Path = filepath.Join(baseUrl.Path, addUrl.Path)
+	baseUrl.Path = path.Join(baseUrl.Path, addUrl.Path)
 
 	return baseUrl, nil
 }

--- a/pkg/scraping/client_test.go
+++ b/pkg/scraping/client_test.go
@@ -1,0 +1,25 @@
+package scraping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinPath(t *testing.T) {
+	tests := []struct {
+		base string
+		part string
+		url  string
+	}{
+		{"http://some-url.biz/4/l/1/", "/new/part/", "http://some-url.biz/4/l/1/new/part"},
+		{"http://some-url.biz/432/l/1", "new/part/", "http://some-url.biz/432/l/1/new/part"},
+		{"http://some-url.biz/4/ldgdf/1", "new/part/", "http://some-url.biz/4/ldgdf/1/new/part"},
+		{"some-url.biz/4/l/1/QWE", "new/part/", "some-url.biz/4/l/1/QWE/new/part"},
+	}
+	for _, tc := range tests {
+		url, err := joinPath(tc.base, tc.part)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.url, url.String())
+	}
+}


### PR DESCRIPTION
For some reason, path.Join function removes `/`, so we had to parse raws first and then join them