### PR TITLE
Support env variables for services configuration parameters.

### DIFF
--- a/cmd/bots/discord/discord.go
+++ b/cmd/bots/discord/discord.go
@@ -12,6 +12,7 @@ import (
 	"nodemon/cmd/bots/internal/common/messaging"
 	"nodemon/cmd/bots/internal/discord/handlers"
 	"nodemon/pkg/messaging/pair"
+	"nodemon/pkg/tools"
 
 	"github.com/pkg/errors"
 	"github.com/procyon-projects/chrono"
@@ -41,15 +42,15 @@ type discordBotConfig struct {
 
 func newDiscordBotConfigConfig() *discordBotConfig {
 	c := new(discordBotConfig)
-	flag.StringVar(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
 		"ipc:///tmp/discord/nano-msg-nodemon-pubsub.ipc", "Nanomsg IPC URL for pubsub socket")
-	flag.StringVar(&c.nanomsgPairURL, "nano-msg-pair-discord-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPairURL, "nano-msg-pair-discord-url",
 		"ipc:///tmp/nano-msg-nodemon-pair.ipc", "Nanomsg IPC URL for pair socket")
-	flag.StringVar(&c.discordBotToken, "discord-bot-token",
+	tools.StringVarFlagWithEnv(&c.discordBotToken, "discord-bot-token",
 		"", "The secret token used to authenticate the bot")
-	flag.StringVar(&c.discordChatID, "discord-chat-id",
+	tools.StringVarFlagWithEnv(&c.discordChatID, "discord-chat-id",
 		"", "discord chat ID to send alerts through")
-	flag.StringVar(&c.logLevel, "log-level", "INFO",
+	tools.StringVarFlagWithEnv(&c.logLevel, "log-level", "INFO",
 		"Logging level. Supported levels: DEBUG, INFO, WARN, ERROR, FATAL. Default logging level INFO.")
 	return c
 }

--- a/cmd/bots/telegram/telegram.go
+++ b/cmd/bots/telegram/telegram.go
@@ -14,6 +14,7 @@ import (
 	"nodemon/cmd/bots/internal/telegram/config"
 	"nodemon/cmd/bots/internal/telegram/handlers"
 	"nodemon/pkg/messaging/pair"
+	"nodemon/pkg/tools"
 
 	"github.com/procyon-projects/chrono"
 	gow "github.com/wavesplatform/gowaves/pkg/util/common"
@@ -46,21 +47,21 @@ type telegramBotConfig struct {
 
 func newTelegramBotConfig() *telegramBotConfig {
 	c := new(telegramBotConfig)
-	flag.StringVar(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
 		"ipc:///tmp/telegram/nano-msg-nodemon-pubsub.ipc", "Nanomsg IPC URL for pubsub socket")
-	flag.StringVar(&c.nanomsgPairURL, "nano-msg-pair-telegram-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPairURL, "nano-msg-pair-telegram-url",
 		"ipc:///tmp/nano-msg-nodemon-pair.ipc", "Nanomsg IPC URL for pair socket")
-	flag.StringVar(&c.behavior, "behavior", "webhook",
+	tools.StringVarFlagWithEnv(&c.behavior, "behavior", "webhook",
 		"Behavior is either webhook or polling")
-	flag.StringVar(&c.webhookLocalAddress, "webhook-local-address",
+	tools.StringVarFlagWithEnv(&c.webhookLocalAddress, "webhook-local-address",
 		":8081", "The application's webhook address is :8081 by default")
-	flag.StringVar(&c.tgBotToken, "tg-bot-token", "",
+	tools.StringVarFlagWithEnv(&c.tgBotToken, "tg-bot-token", "",
 		"The secret token used to authenticate the bot")
-	flag.StringVar(&c.publicURL, "public-url", "",
+	tools.StringVarFlagWithEnv(&c.publicURL, "public-url", "",
 		"The public url for websocket only")
-	flag.Int64Var(&c.tgChatID, "telegram-chat-id",
+	tools.Int64VarFlagWithEnv(&c.tgChatID, "telegram-chat-id",
 		0, "telegram chat ID to send alerts through")
-	flag.StringVar(&c.logLevel, "log-level", "INFO",
+	tools.StringVarFlagWithEnv(&c.logLevel, "log-level", "INFO",
 		"Logging level. Supported levels: DEBUG, INFO, WARN, ERROR, FATAL. Default logging level INFO.")
 	return c
 }

--- a/cmd/nodemon/nodemon.go
+++ b/cmd/nodemon/nodemon.go
@@ -68,12 +68,12 @@ func (n *nodemonVaultConfig) present() bool {
 
 func newNodemonVaultConfig() *nodemonVaultConfig {
 	c := new(nodemonVaultConfig)
-	flag.StringVar(&c.address, "vault-address", "", "Vault server address.")
-	flag.StringVar(&c.user, "vault-user", "", "Vault user.")
-	flag.StringVar(&c.password, "vault-password", "", "Vault user's password.")
-	flag.StringVar(&c.mountPath, "vault-mount-path", "gonodemonitoring",
+	tools.StringVarFlagWithEnv(&c.address, "vault-address", "", "Vault server address.")
+	tools.StringVarFlagWithEnv(&c.user, "vault-user", "", "Vault user.")
+	tools.StringVarFlagWithEnv(&c.password, "vault-password", "", "Vault user's password.")
+	tools.StringVarFlagWithEnv(&c.mountPath, "vault-mount-path", "gonodemonitoring",
 		"Vault mount path for nodemon nodes storage.")
-	flag.StringVar(&c.secretPath, "vault-secret-path", "",
+	tools.StringVarFlagWithEnv(&c.secretPath, "vault-secret-path", "",
 		"Vault secret where nodemon nodes will be saved")
 	return c
 }
@@ -119,29 +119,29 @@ type nodemonConfig struct {
 
 func newNodemonConfig() *nodemonConfig {
 	c := new(nodemonConfig)
-	flag.StringVar(&c.storage, "storage",
+	tools.StringVarFlagWithEnv(&c.storage, "storage",
 		".nodes.json", "Path to storage. Default value is \".nodes.json\"")
-	flag.StringVar(&c.nodes, "nodes", "",
+	tools.StringVarFlagWithEnv(&c.nodes, "nodes", "",
 		"Initial list of Waves Blockchain nodes to monitor. Provide comma separated list of REST API URLs here.")
-	flag.StringVar(&c.bindAddress, "bind", ":8080",
+	tools.StringVarFlagWithEnv(&c.bindAddress, "bind", ":8080",
 		"Local network address to bind the HTTP API of the service on. Default value is \":8080\".")
-	flag.DurationVar(&c.interval, "interval",
+	tools.DurationVarFlagWithEnv(&c.interval, "interval",
 		defaultPollingInterval, "Polling interval, seconds. Default value is 60")
-	flag.DurationVar(&c.timeout, "timeout",
+	tools.DurationVarFlagWithEnv(&c.timeout, "timeout",
 		defaultNetworkTimeout, "Network timeout, seconds. Default value is 15")
-	flag.IntVar(&c.baseTargetThreshold, "base-target-threshold",
+	tools.IntVarFlagWithEnv(&c.baseTargetThreshold, "base-target-threshold",
 		0, "Base target threshold. Must be specified")
-	flag.StringVar(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPubSubURL, "nano-msg-pubsub-url",
 		"ipc:///tmp/nano-msg-pubsub.ipc", "Nanomsg IPC URL for pubsub socket")
-	flag.StringVar(&c.nanomsgPairTelegramURL, "nano-msg-pair-telegram-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPairTelegramURL, "nano-msg-pair-telegram-url",
 		"", "Nanomsg IPC URL for pair socket")
-	flag.StringVar(&c.nanomsgPairDiscordURL, "nano-msg-pair-discord-url",
+	tools.StringVarFlagWithEnv(&c.nanomsgPairDiscordURL, "nano-msg-pair-discord-url",
 		"", "Nanomsg IPC URL for pair socket")
-	flag.DurationVar(&c.retention, "retention", defaultRetentionDuration,
+	tools.DurationVarFlagWithEnv(&c.retention, "retention", defaultRetentionDuration,
 		"Events retention duration. Default value is 12h")
-	flag.DurationVar(&c.apiReadTimeout, "api-read-timeout", defaultAPIReadTimeout,
+	tools.DurationVarFlagWithEnv(&c.apiReadTimeout, "api-read-timeout", defaultAPIReadTimeout,
 		"HTTP API read timeout. Default value is 30s.")
-	flag.StringVar(&c.logLevel, "log-level", "INFO",
+	tools.StringVarFlagWithEnv(&c.logLevel, "log-level", "INFO",
 		"Logging level. Supported levels: DEBUG, INFO, WARN, ERROR, FATAL. Default logging level INFO.")
 	c.vault = newNodemonVaultConfig()
 	return c

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/vault/api/auth/userpass v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/procyon-projects/chrono v1.1.2
+	github.com/stoewer/go-strcase v1.3.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/buntdb v1.3.0
 	github.com/wavesplatform/gowaves v0.10.6

--- a/go.sum
+++ b/go.sum
@@ -438,10 +438,13 @@ github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
+github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
+github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -451,6 +454,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=

--- a/pkg/tools/flag.go
+++ b/pkg/tools/flag.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/stoewer/go-strcase"
+)
+
+func lookupEnvOrValue[T any](envKey string, defaultVal T, parse func(val string) (T, error)) T {
+	if val, ok := os.LookupEnv(envKey); ok {
+		parsedVal, err := parse(val)
+		if err != nil {
+			log.Fatalf("Failed to parse %q environment variable value=%q as (%T): %v", envKey, val, defaultVal, err)
+		}
+		return parsedVal
+	}
+	return defaultVal
+}
+
+func lookupEnvOrString(envKey string, defaultVal string) string {
+	return lookupEnvOrValue(envKey, defaultVal, func(val string) (string, error) {
+		return val, nil
+	})
+}
+
+func lookupEnvOrInt(envKey string, defaultVal int) int {
+	return lookupEnvOrValue(envKey, defaultVal, strconv.Atoi)
+}
+
+func lookupEnvOrInt64(envKey string, defaultVal int64) int64 {
+	return lookupEnvOrValue(envKey, defaultVal, func(val string) (int64, error) {
+		return strconv.ParseInt(val, 10, 64)
+	})
+}
+
+func lookupEnvOrDuration(envKey string, defaultVal time.Duration) time.Duration {
+	return lookupEnvOrValue(envKey, defaultVal, time.ParseDuration)
+}
+
+// StringVarFlagWithEnv allows to define string flag which default value
+// is overridable when corresponding upper snake case environment variable is set.
+func StringVarFlagWithEnv(p *string, name, value, usage string) {
+	flag.StringVar(p, name, lookupEnvOrString(strcase.UpperSnakeCase(name), value), usage)
+}
+
+// IntVarFlagWithEnv allows to define int flag which default value
+// is overridable when corresponding upper snake case environment variable is set.
+func IntVarFlagWithEnv(p *int, name string, value int, usage string) {
+	flag.IntVar(p, name, lookupEnvOrInt(strcase.UpperSnakeCase(name), value), usage)
+}
+
+// Int64VarFlagWithEnv allows to define int64 flag which default value
+// is overridable when corresponding upper snake case environment variable is set.
+func Int64VarFlagWithEnv(p *int64, name string, value int64, usage string) {
+	flag.Int64Var(p, name, lookupEnvOrInt64(strcase.UpperSnakeCase(name), value), usage)
+}
+
+// DurationVarFlagWithEnv allows to define duration flag which default value
+// is overridable when corresponding upper snake case environment variable is set.
+func DurationVarFlagWithEnv(p *time.Duration, name string, value time.Duration, usage string) {
+	flag.DurationVar(p, name, lookupEnvOrDuration(strcase.UpperSnakeCase(name), value), usage)
+}


### PR DESCRIPTION
Now any CLI flag default value is overridable with corresponding environment variable. To override CLI flag default value transform flag name to the upper (screaming) snake case environment variable name with the same words order.