### PR TITLE
Fix 'NewVaultSimpleClient' constructor

### DIFF
--- a/pkg/clients/vault.go
+++ b/pkg/clients/vault.go
@@ -128,7 +128,7 @@ func vaultLogin(ctx context.Context, client *vault.Client, user, pass string) (*
 		return nil, errors.Wrap(err, "unable to login to userpass auth method")
 	}
 	if authInfo == nil {
-		return nil, errors.Wrap(err, "no auth info was returned after login")
+		return nil, errors.New("no auth info was returned after login")
 	}
 
 	return authInfo, nil


### PR DESCRIPTION
- Wrap correct error at first login attempt
- Set vault address with 'config.ParseAddress' method
- Fix 'authInfo' value check in 'vaultLogin' function