### PR TITLE
Add alert confirmations for L2 height collector errors

### DIFF
--- a/pkg/analysis/l2/l2analyzer.go
+++ b/pkg/analysis/l2/l2analyzer.go
@@ -200,7 +200,7 @@ func vacuumAlerts(
 	}
 }
 
-// defaultAlertVacuumQuota is a default value for the [storage.AlertsStorage] vacuum quota.
+// defaultAlertVacuumQuota is a default value for the `storage.AlertsStorage` vacuum quota.
 // It is calculated as the number of vacuum stages required to vacuum an alert.
 // The formula is: l2NodesSameHeightTimerDuration / heightCollectorTimeout + 1 + 4, where:
 // - l2NodesSameHeightTimerDuration is the duration of the timer that triggers the alert about the same height of an L2,

--- a/pkg/entities/alerts.go
+++ b/pkg/entities/alerts.go
@@ -151,6 +151,13 @@ type SimpleAlert struct {
 	Description string `json:"description"`
 }
 
+func NewSimpleAlert(timestamp int64, description string) *SimpleAlert {
+	return &SimpleAlert{
+		Timestamp:   timestamp,
+		Description: description,
+	}
+}
+
 func (a *SimpleAlert) Name() AlertName {
 	return SimpleAlertName
 }


### PR DESCRIPTION
Also changed alert type for L2 height collector: `InternalAlert` -> `SimpleAlert`.