### PR TITLE
Bump go to 1.26.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
           fetch-depth: 0
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: false # don't save & restore build caches because golangci-lint action does it internally
       - name: Get dependencies
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           check-latest: true
           cache: true
       - name: Run go list

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module nodemon
 
-go 1.25.0
+go 1.26.0
 
 require (
 	codnect.io/chrono v1.1.3


### PR DESCRIPTION
This pull request updates the Go version used across the project from 1.25 to 1.26. The changes ensure that both the build and security workflows, as well as the module definition, are aligned with Go 1.26.

Go version upgrade:

* Updated the Go version in the `go.mod` file from `1.25.0` to `1.26.0` to set the project baseline to Go 1.26.0.
* Updated the Go version in the `.github/workflows/go.yml` workflow for both build and test jobs to use `1.26.x` instead of `1.25.x`. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL18-R21) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL42-R45)
* Updated the Go version in the `.github/workflows/security.yml` workflow to use `1.26.x` instead of `1.25.x`.